### PR TITLE
Update utils version and remove html-to-text

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,6 +1,283 @@
 {
+    "name": "scripts",
+    "lockfileVersion": 2,
     "requires": true,
-    "lockfileVersion": 1,
+    "packages": {
+        "": {
+            "dependencies": {
+                "@smartface/contx": "^3.0.2",
+                "@smartface/router": "^1.6.2",
+                "@smartface/styler": "^2.0.0",
+                "js-base": "^1.0.5",
+                "keyboardlayout": "^2.0.7",
+                "materialtextbox": "^4.0.15",
+                "sf-core": "^4.3.0",
+                "sf-extension-utils": "^14.0.0",
+                "source-map": "0.6.1"
+            }
+        },
+        "node_modules/@smartface/contx": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@smartface/contx/-/contx-3.0.2.tgz",
+            "integrity": "sha512-ysYleQZJC4umwYMpeNhlof5BLDU6ItUO8y9jEXQfZXeAKQ6nPrqQrYm/AtAxhyDeR+Z0Mrk+DGrecGjP4qvOXg==",
+            "dependencies": {
+                "@smartface/styler": "^2.0.0",
+                "filtrex": "^0.5.4"
+            }
+        },
+        "node_modules/@smartface/router": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/@smartface/router/-/router-1.6.2.tgz",
+            "integrity": "sha512-Rh/a3Iyqw2fv+7lrdaYMUjztcHF5NHbMrst5STVl89thAN+gdW8DiqTIZABKE3U0WqtW1lk8Dz2yd4VPjPx1vg==",
+            "dependencies": {
+                "path-to-regexp": "^2.4.0",
+                "resolve-pathname": "^2.2.0"
+            }
+        },
+        "node_modules/@smartface/styler": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@smartface/styler/-/styler-2.0.0.tgz",
+            "integrity": "sha512-XLgoSUdXM8l0xHFIHV85ZEwzlYl07be2qi+Ca9p3lU1oE8STetxLFR3z7LD8eIq5Wp0Vzoh9xDsGdu0gTwo/dw=="
+        },
+        "node_modules/decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/filter-obj": {
+            "version": "1.1.0",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/filter-obj/-/filter-obj-1.1.0.tgz",
+            "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/filtrex": {
+            "version": "0.5.4",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/filtrex/-/filtrex-0.5.4.tgz",
+            "integrity": "sha1-mAddUY8GjE9Yt7WJoifZi9n2OV0=",
+            "license": "MIT"
+        },
+        "node_modules/for-in": {
+            "version": "1.0.2",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/html-parse-stringify": {
+            "version": "1.0.2",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/html-parse-stringify/-/html-parse-stringify-1.0.2.tgz",
+            "integrity": "sha1-EgjpjNdDCtfvsS4ees7pIU/SIoM=",
+            "license": "MIT",
+            "dependencies": {
+                "void-elements": "^1.0.0"
+            }
+        },
+        "node_modules/is-extendable": {
+            "version": "1.0.1",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/is-extendable/-/is-extendable-1.0.1.tgz",
+            "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+            "license": "MIT",
+            "dependencies": {
+                "is-plain-object": "^2.0.4"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "license": "MIT",
+            "dependencies": {
+                "isobject": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/isobject": {
+            "version": "3.0.1",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/js-base": {
+            "version": "1.0.5",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/js-base/-/js-base-1.0.5.tgz",
+            "integrity": "sha512-riZS7qUHOrEq26nK1cR7TjYSl7iJXWjNnW3nP4yFUs4vjfOYMUVD44ku/1b0FcJ1xDG3aQXoARx0S+4ZuUQZ5A==",
+            "license": "MIT"
+        },
+        "node_modules/keyboardlayout": {
+            "version": "2.0.7",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/keyboardlayout/-/keyboardlayout-2.0.7.tgz",
+            "integrity": "sha512-JDbmlClpjOM9TEehHJcH4njccO7zhd6D1Ovg5Ig3BPHQx7m/TJ3nuAZtHHKiXQLkwyW8/REPbZqp4ton9Qrtyw==",
+            "hasInstallScript": true,
+            "license": "ISC",
+            "dependencies": {
+                "@smartface/contx": "^3.0.1"
+            }
+        },
+        "node_modules/materialtextbox": {
+            "version": "4.0.22",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/materialtextbox/-/materialtextbox-4.0.22.tgz",
+            "integrity": "sha512-wC8rwh8ZDnZzj8s5DkskB5DCqqwRm8Iq0dhV+UN8Mz3aziZ2cvYlojxiE2hmWGMHN+PtCLOg+HzxYz7Fy1q4BA==",
+            "hasInstallScript": true,
+            "license": "ISC",
+            "dependencies": {
+                "@smartface/contx": "^3.0.1"
+            }
+        },
+        "node_modules/mixin-deep": {
+            "version": "1.3.2",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/mixin-deep/-/mixin-deep-1.3.2.tgz",
+            "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+            "license": "MIT",
+            "dependencies": {
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-to-regexp": {
+            "version": "2.4.0",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+            "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+            "license": "MIT"
+        },
+        "node_modules/query-string": {
+            "version": "6.14.1",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/query-string/-/query-string-6.14.1.tgz",
+            "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
+            "license": "MIT",
+            "dependencies": {
+                "decode-uri-component": "^0.2.0",
+                "filter-obj": "^1.1.0",
+                "split-on-first": "^1.0.0",
+                "strict-uri-encode": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/resolve-pathname": {
+            "version": "2.2.0",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
+            "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg==",
+            "license": "MIT"
+        },
+        "node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/sf-core": {
+            "version": "4.3.1",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/sf-core/-/sf-core-4.3.1.tgz",
+            "integrity": "sha1-b1VBIUJgPLPnNFeTTQOZPaY1lb0=",
+            "license": "ISC"
+        },
+        "node_modules/sf-extension-utils": {
+            "version": "14.9.3",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/sf-extension-utils/-/sf-extension-utils-14.9.3.tgz",
+            "integrity": "sha512-UBLYtneF1dhdeP9terMEdIQ+DKBgIEYEkTD5/0ICQpdgjINouSPKDjWzNHyNCI3sOtjjrddTHo88teYbi5AJmQ==",
+            "license": "MIT",
+            "dependencies": {
+                "html-parse-stringify": "1.0.2",
+                "mixin-deep": "^1.3.1",
+                "query-string": "^6.10.1",
+                "semver": "^5.7.1",
+                "squel": "^5.13.0",
+                "tinycolor2": "^1.4.1",
+                "wolfy87-eventemitter": "^5.2.9"
+            },
+            "peerDependencies": {
+                "@smartface/contx": "^3.0.1",
+                "sf-core": "^4.0.0"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/split-on-first": {
+            "version": "1.1.0",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/split-on-first/-/split-on-first-1.1.0.tgz",
+            "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/squel": {
+            "version": "5.13.0",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/squel/-/squel-5.13.0.tgz",
+            "integrity": "sha512-Fzd8zqbuqNwzodO3yO6MkX8qiDoVBuwqAaa3eKNz4idhBf24IQHbatBhLUiHAGGl962eGvPVRxzRuFWZlSf49w==",
+            "deprecated": "Squel is no longer maintained. We recommend knex as an alternative.",
+            "engines": {
+                "node": ">= 0.12.0"
+            }
+        },
+        "node_modules/strict-uri-encode": {
+            "version": "2.0.0",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+            "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/tinycolor2": {
+            "version": "1.4.2",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/tinycolor2/-/tinycolor2-1.4.2.tgz",
+            "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/void-elements": {
+            "version": "1.0.0",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/void-elements/-/void-elements-1.0.0.tgz",
+            "integrity": "sha1-bl2x411ZH1rGkM4aNA95OoF7LCo=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/wolfy87-eventemitter": {
+            "version": "5.2.9",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/wolfy87-eventemitter/-/wolfy87-eventemitter-5.2.9.tgz",
+            "integrity": "sha512-P+6vtWyuDw+MB01X7UeF8TaHBvbCovf4HPEMF/SV7BdDc1SMTiBy13SRD71lQh4ExFTG1d/WNzDGDCyOKSMblw==",
+            "license": "Unlicense"
+        }
+    },
     "dependencies": {
         "@smartface/contx": {
             "version": "3.0.2",
@@ -9,14 +286,6 @@
             "requires": {
                 "@smartface/styler": "^2.0.0",
                 "filtrex": "^0.5.4"
-            }
-        },
-        "@smartface/html-to-text": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@smartface/html-to-text/-/html-to-text-1.2.0.tgz",
-            "integrity": "sha512-yKoQY2nfWiVEfXKdqvtswxPTQjt+WeNZl8gqnUXxRzZcm/trzcyHx8KGzTQHdLysQCDtOQhyIZXPTaWlFaFzFg==",
-            "requires": {
-                "html-parse-stringify": "1.0.2"
             }
         },
         "@smartface/router": {
@@ -35,7 +304,7 @@
         },
         "decode-uri-component": {
             "version": "0.2.0",
-            "resolved": "http://cd.smartface.io/nexus/content/groups/npm-all-public/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
         "filter-obj": {
@@ -50,12 +319,12 @@
         },
         "for-in": {
             "version": "1.0.2",
-            "resolved": "http://cd.smartface.io/nexus/content/groups/npm-all-public/for-in/-/for-in-1.0.2.tgz",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/for-in/-/for-in-1.0.2.tgz",
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
         },
         "html-parse-stringify": {
             "version": "1.0.2",
-            "resolved": "http://cd.smartface.io/nexus/content/groups/npm-all-public/html-parse-stringify/-/html-parse-stringify-1.0.2.tgz",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/html-parse-stringify/-/html-parse-stringify-1.0.2.tgz",
             "integrity": "sha1-EgjpjNdDCtfvsS4ees7pIU/SIoM=",
             "requires": {
                 "void-elements": "^1.0.0"
@@ -63,7 +332,7 @@
         },
         "is-extendable": {
             "version": "1.0.1",
-            "resolved": "http://cd.smartface.io/nexus/content/groups/npm-all-public/is-extendable/-/is-extendable-1.0.1.tgz",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/is-extendable/-/is-extendable-1.0.1.tgz",
             "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
             "requires": {
                 "is-plain-object": "^2.0.4"
@@ -71,7 +340,7 @@
         },
         "is-plain-object": {
             "version": "2.0.4",
-            "resolved": "http://cd.smartface.io/nexus/content/groups/npm-all-public/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "requires": {
                 "isobject": "^3.0.1"
@@ -79,7 +348,7 @@
         },
         "isobject": {
             "version": "3.0.1",
-            "resolved": "http://cd.smartface.io/nexus/content/groups/npm-all-public/isobject/-/isobject-3.0.1.tgz",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/isobject/-/isobject-3.0.1.tgz",
             "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
         "js-base": {
@@ -96,16 +365,16 @@
             }
         },
         "materialtextbox": {
-            "version": "4.0.15",
-            "resolved": "https://cd.smartface.io/repository/npm-all-public/materialtextbox/-/materialtextbox-4.0.15.tgz",
-            "integrity": "sha512-dHbTXSX2c3Ac1wC2EREK+GRAovOX2BCsW7Y1MW1A8i7qYdPBqT+oC7801N3WaIJDqqP/ZHerzIUZjWN2uwdvAg==",
+            "version": "4.0.22",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/materialtextbox/-/materialtextbox-4.0.22.tgz",
+            "integrity": "sha512-wC8rwh8ZDnZzj8s5DkskB5DCqqwRm8Iq0dhV+UN8Mz3aziZ2cvYlojxiE2hmWGMHN+PtCLOg+HzxYz7Fy1q4BA==",
             "requires": {
                 "@smartface/contx": "^3.0.1"
             }
         },
         "mixin-deep": {
             "version": "1.3.2",
-            "resolved": "http://cd.smartface.io/nexus/content/groups/npm-all-public/mixin-deep/-/mixin-deep-1.3.2.tgz",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/mixin-deep/-/mixin-deep-1.3.2.tgz",
             "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
             "requires": {
                 "for-in": "^1.0.2",
@@ -114,13 +383,13 @@
         },
         "path-to-regexp": {
             "version": "2.4.0",
-            "resolved": "http://cd.smartface.io/nexus/content/groups/npm-all-public/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
             "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w=="
         },
         "query-string": {
-            "version": "6.14.0",
-            "resolved": "https://cd.smartface.io/repository/npm-all-public/query-string/-/query-string-6.14.0.tgz",
-            "integrity": "sha512-In3o+lUxlgejoVJgwEdYtdxrmlL0cQWJXj0+kkI7RWVo7hg5AhFtybeKlC9Dpgbr8eOC4ydpEh8017WwyfzqVQ==",
+            "version": "6.14.1",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/query-string/-/query-string-6.14.1.tgz",
+            "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
             "requires": {
                 "decode-uri-component": "^0.2.0",
                 "filter-obj": "^1.1.0",
@@ -130,25 +399,25 @@
         },
         "resolve-pathname": {
             "version": "2.2.0",
-            "resolved": "http://cd.smartface.io/nexus/content/groups/npm-all-public/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
             "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
         },
         "semver": {
             "version": "5.7.1",
-            "resolved": "http://cd.smartface.io/nexus/content/groups/npm-all-public/semver/-/semver-5.7.1.tgz",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/semver/-/semver-5.7.1.tgz",
             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         },
         "sf-core": {
-            "version": "4.3.0",
-            "resolved": "https://cd.smartface.io/repository/npm-all-public/sf-core/-/sf-core-4.3.0.tgz",
-            "integrity": "sha1-443XVGR60W1AHRxME2NP9BVrK14="
+            "version": "4.3.1",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/sf-core/-/sf-core-4.3.1.tgz",
+            "integrity": "sha1-b1VBIUJgPLPnNFeTTQOZPaY1lb0="
         },
         "sf-extension-utils": {
-            "version": "14.5.0",
-            "resolved": "https://cd.smartface.io/repository/npm-all-public/sf-extension-utils/-/sf-extension-utils-14.5.0.tgz",
-            "integrity": "sha512-ke9kIIaW/yv11If4tUKc6pSse+9vMIz8pE86IXc1lTb8vHZniVE1GNpNR4XJDSceDJ9lWEC6sCH/jASYf0joCw==",
+            "version": "14.9.3",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/sf-extension-utils/-/sf-extension-utils-14.9.3.tgz",
+            "integrity": "sha512-UBLYtneF1dhdeP9terMEdIQ+DKBgIEYEkTD5/0ICQpdgjINouSPKDjWzNHyNCI3sOtjjrddTHo88teYbi5AJmQ==",
             "requires": {
-                "@smartface/contx": "^3.0.1",
+                "html-parse-stringify": "1.0.2",
                 "mixin-deep": "^1.3.1",
                 "query-string": "^6.10.1",
                 "semver": "^5.7.1",
@@ -159,22 +428,22 @@
         },
         "source-map": {
             "version": "0.6.1",
-            "resolved": "http://cd.smartface.io/nexus/content/groups/npm-all-public/source-map/-/source-map-0.6.1.tgz",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "split-on-first": {
             "version": "1.1.0",
-            "resolved": "http://cd.smartface.io/nexus/content/groups/npm-all-public/split-on-first/-/split-on-first-1.1.0.tgz",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/split-on-first/-/split-on-first-1.1.0.tgz",
             "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
         },
         "squel": {
             "version": "5.13.0",
-            "resolved": "http://cd.smartface.io/nexus/content/groups/npm-all-public/squel/-/squel-5.13.0.tgz",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/squel/-/squel-5.13.0.tgz",
             "integrity": "sha512-Fzd8zqbuqNwzodO3yO6MkX8qiDoVBuwqAaa3eKNz4idhBf24IQHbatBhLUiHAGGl962eGvPVRxzRuFWZlSf49w=="
         },
         "strict-uri-encode": {
             "version": "2.0.0",
-            "resolved": "http://cd.smartface.io/nexus/content/groups/npm-all-public/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
             "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
         },
         "tinycolor2": {
@@ -184,12 +453,12 @@
         },
         "void-elements": {
             "version": "1.0.0",
-            "resolved": "http://cd.smartface.io/nexus/content/groups/npm-all-public/void-elements/-/void-elements-1.0.0.tgz",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/void-elements/-/void-elements-1.0.0.tgz",
             "integrity": "sha1-bl2x411ZH1rGkM4aNA95OoF7LCo="
         },
         "wolfy87-eventemitter": {
             "version": "5.2.9",
-            "resolved": "http://cd.smartface.io/nexus/content/groups/npm-all-public/wolfy87-eventemitter/-/wolfy87-eventemitter-5.2.9.tgz",
+            "resolved": "https://cd.smartface.io/repository/npm-all-public/wolfy87-eventemitter/-/wolfy87-eventemitter-5.2.9.tgz",
             "integrity": "sha512-P+6vtWyuDw+MB01X7UeF8TaHBvbCovf4HPEMF/SV7BdDc1SMTiBy13SRD71lQh4ExFTG1d/WNzDGDCyOKSMblw=="
         }
     }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,14 +1,13 @@
 {
     "dependencies": {
         "@smartface/contx": "^3.0.2",
-        "@smartface/html-to-text": "^1.1.1",
         "@smartface/router": "^1.6.2",
         "@smartface/styler": "^2.0.0",
         "js-base": "^1.0.5",
         "keyboardlayout": "^2.0.7",
         "materialtextbox": "^4.0.15",
         "sf-core": "^4.3.0",
-        "sf-extension-utils": "^14.5.0",
+        "sf-extension-utils": "^14.0.0",
         "source-map": "0.6.1"
     }
 }


### PR DESCRIPTION
Since html-to-text used on Smartface Projects were moved into utils, use that.

`@smartface/html-to-text` will stay as is in workspace directory since it is a required dependency on transpiler.